### PR TITLE
add Fargate Service shared module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ override.tf.json
 # example: *tfplan*
 
 /iac/*/build/*
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Admin Systems: Fargate Infrastructure-as-Code Modules
 
-When referencing these modules in your IaC module's source, DO NOT reference the master branch as there may be breaking changes from future releases. Only reference a specific release tag, e.g.: ?ref=tags/v1.0.2
+When referencing these modules in your IaC module's source, DO NOT reference the master branch as there may be breaking changes from future releases. Only reference a specific release tag, e.g. ?ref=tags/v1.0.2
 ```
 module "fargate_example" {
   source = "github.com/NIT-Administrative-Systems/AS-fargate-modules//modules/ecs_fargate_service?ref=tags/v1.0.0"

--- a/README.md
+++ b/README.md
@@ -143,11 +143,12 @@ Available outputs from the modules:
 | Name | Description |
 | ---- | ----------- |
 | parameters | Secret SSM parameters. Output is used by Jenkins to set the secret text. |
+| ecs_service_name | The name of the ECS service. Useful in AWS ECS cli commands, e.g. to redeploy the service after pushing a new image | 
+| cluster_name | The name of the ecs cluster created. Useful in AWS ECS cli commands, e.g. to redeploy the service after pushing a new image | 
 | kms_arn | The arn of the encryption key used for the SSM secrets so you can use it to encrypt elsewhere | 
-| task_definition | The arn of the task definition created. Useful in AWS ECS cli commands e.g. to see if your task is running |  
-| cluster_name | The name of the ecs cluster created. Useful in AWS ECS cli commands  e.g. to run a one-off task or see what's running on your cluster | 
-| security_group | The id of the security group used. May be useful in AWS ECS cli commands, e.g. to run a one-off task | 
-| subnet_ids | The list of subnet ids - may be useful in AWS ECS cli commands e.g. to run a one-off task |
+| task_definition | The arn of the task definition created. |  
+| security_group | The id of the security group used. | 
+| subnet_ids | The list of subnet ids. |
 | cw_log_group_name | The name of the cloudwatch log group created for your task. Useful for querying logs via AWS logs cli |
 | cw_log_stream_prefix | The name of the cloudwatch log prefix for your task logs. Useful for querying logs via AWS logs cli |
 | task_short_name | The task name (cleaned and shortened) used to name resources | 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is a Terraform IaC module for creating a fargate task with a single container, which runs on a schedule via cloudwatch event rule, and secrets management through SSM. It implements the Admin Systems practices outlined on our cloud practice site. This solution may be ideal for a serverless architecture which is resource-intensive or long-running enough to exceed the lambda duration/memory limitations e.g. periodic longer-running batch jobs, etc. 
 
-When `terraform apply` updates the task definition, or the image has been updated, future tasks launched will use the new image/definition version but any tasks already running will not recieve the changes. 
+When you push a new container image or apply a change to the task definition, future tasks launched will use the new version but any tasks already running will not recieve the changes. 
 
 Fargate task charges are based on the vCPU and Memory resources while your containerized application is running. 
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Available outputs from the modules:
 | Name | Description |
 | ---- | ----------- |
 | parameters | Secret SSM parameters. Output is used by Jenkins to set the secret text. |
-| ecs_service_name | The name of the ECS service. Useful in AWS ECS cli commands, e.g. to redeploy the service after pushing a new image | 
+| service_name | The name of the ECS service. Useful in AWS ECS cli commands, e.g. to redeploy the service after pushing a new image | 
 | cluster_name | The name of the ecs cluster created. Useful in AWS ECS cli commands, e.g. to redeploy the service after pushing a new image | 
 | kms_arn | The arn of the encryption key used for the SSM secrets so you can use it to encrypt elsewhere | 
 | task_definition | The arn of the task definition created. |  

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # Admin Systems: Fargate Infrastructure-as-Code Modules
 
-<span style="color:orange">When referencing these modules in your IaC module's source, DO NOT reference the master branch as there may be breaking changes from future releases. Only reference a specific release tag, e.g.: ?ref=tags/v1.0.2</span>
+```diff
+! When referencing these modules in your IaC module's source, DO NOT reference the master branch as there may be breaking changes from future releases. Only reference a specific release tag, e.g.: ?ref=tags/v1.0.2
+```
 ```
 module "fargate_example" {
   source = "github.com/NIT-Administrative-Systems/AS-fargate-modules//modules/ecs_fargate_service?ref=tags/v1.0.0"
+  ...
+}
 ```
 
 ## Fargate Task 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Available outputs from the modules:
 | task_short_name | The task name (cleaned and shortened) used to name resources | 
 
 ### Complete Example
-A complete end-to-end example implementing implementing the shared Fargate Service module with an ECR repository, building the image, etc. for a simple Node/Express application can be found in the [NUIT Administrative Systems Fargate Service Example repository](https://github.com/NIT-Administrative-Systems/as-fargate-service-example)
+A complete end-to-end example implementing the shared Fargate Service module with an ECR repository, building the image, etc. for a simple Node/Express application can be found in the [NUIT Administrative Systems Fargate Service Example repository](https://github.com/NIT-Administrative-Systems/as-fargate-service-example)
 
 ## Contributing
 Find another input you would like parameterized? Need another output? Want to clarify something in the documentation? Pull requests welcome!

--- a/README.md
+++ b/README.md
@@ -71,18 +71,10 @@ Available inputs to pass into the modules:
 | env | Short name for your app's environment | Yes | string | Required parameters do not have a default. | 
 | task_name | Short name to identify your task | Yes | string | Required parameters do not have a default. | 
 | region | AWS region to build in | Yes | string | Required parameters do not have a default. |
-| ecr_repository_url | ECR repository url to pull image from to start the container | Yes | string | Required parameters do not have a default. | 
-| ecr_repository_arn | ECR repositiory arn (to grant task necessary IAM permissions) | Yes | string | Required parameters do not have a default. | 
-| ecr_image_tag | ECR image tag to pull for starting the container | No | string | "latest" |
-| vpc_id | The VPC id to run in. Fargate task definitions require that the network mode is set to awsvpc. The awsvpc network mode provides each task with its own elastic network interface. | Yes | string | Required parameters do not have a default. | 
-| aws_security_group | A terraformed aws_security_group resource to use. | No | Terraform aws_security_group resource | If none is provided, a security group will be created which allows outbound traffic. | 
-| subnet_ids | One or more subnets for the fargate ENI to attach to. | Yes | list(string) | Required parameters do not have a default. | 
-| assign_public_ip | Whether to assign a public IP address to the ENI | No | boolean | false |
-| cw_status | Whether to enable or disable the cloudwatch rule | Yes | boolean | Required parameters do not have a default. | 
-| cw_schedule | The cloudwatch schedule expression to use | Yes | string | Required parameters do not have a default. | 
-| container_env_variables | A list of environment variable maps for your container. Do not include secrets. | No | list(object({name  = string, value = string})) | [] |
-| container_secrets | A list of secrets to create in SSM and inject into the container at runtime. If updated, already running containers will not get new values/params. Names should match Jenkins credential IDs and will be available as env variables when the container runs. Do not use dashes/hyphens. | No | list(string) | [] |
-| container_port_mappings | The list of port mappings for the container | No | list(object({containerPort = number, hostPort = number, protocol = string})) | [] |
+
+Task Definition Inputs
+| Name | Description | Required | Type | Default |
+| ---- | ----------- | -------- | ---- | ------- |
 | task_cpu | The number of CPU units reserved for the task (The container level will use the same value) | No | number | 256 |
 | task_memory | The memory specified for the task level (The container level will use the same value) | No | number | 512 |
 | aws_task_iam_policy_document | An IAM policy document granting permissions for other AWS services your task container is allowed to make calls to when it's running. | No | Terraform aws_iam_policy_document resource | null |
@@ -90,12 +82,37 @@ Available inputs to pass into the modules:
 | task_family | A name for multiple versions of the task definition | No | string | task_name-env |
 | tags | A set of tag name and value pairs for tagging all applicable resources created - useful for cost visibility | No | map(string) | By default resources will be tagged with these standard AS tags: Application: task_name, Environment: env. Override these values by including them in your tags input map. | 
 
+Container Definition Inputs
+| Name | Description | Required | Type | Default |
+| ---- | ----------- | -------- | ---- | ------- |
+| container_env_variables | A list of environment variable maps for your container. Do not include secrets. | No | list(object({name  = string, value = string})) | [] |
+| container_secrets | A list of secrets to create in SSM and inject into the container at runtime. If updated, already running containers will not get new values/params. Names should match Jenkins credential IDs and will be available as env variables when the container runs. Do not use dashes/hyphens. | No | list(string) | [] |
+| container_port_mappings | The list of port mappings for the container | No | list(object({containerPort = number, hostPort = number, protocol = string})) | [] |
+
+ECR Inputs
+| Name | Description | Required | Type | Default |
+| ---- | ----------- | -------- | ---- | ------- |
+| ecr_repository_url | ECR repository url to pull image from to start the container | Yes | string | Required parameters do not have a default. | 
+| ecr_repository_arn | ECR repositiory arn (to grant task necessary IAM permissions) | Yes | string | Required parameters do not have a default. | 
+| ecr_image_tag | ECR image tag to pull for starting the container | No | string | "latest" |
+
+Task Networking Inputs
+| Name | Description | Required | Type | Default |
+| ---- | ----------- | -------- | ---- | ------- |
+| vpc_id | The VPC id to run in. Fargate task definitions require that the network mode is set to awsvpc. The awsvpc network mode provides each task with its own elastic network interface. | Yes | string | Required parameters do not have a default. | 
+| aws_security_group | A terraformed aws_security_group resource to use. | No | Terraform aws_security_group resource | If none is provided, a security group will be created which allows outbound traffic. | 
+| subnet_ids | One or more subnets for the fargate ENI to attach to. | Yes | list(string) | Required parameters do not have a default. | 
+| assign_public_ip | Whether to assign a public IP address to the ENI | No | boolean | false |
+| account_lb_security_group_id | 
+| task_listening_port |
+
 Application Load Balancer Inputs
 | Name | Description | Required | Type | Default |
 | ---- | ----------- | -------- | ---- | ------- |
 | alb_listener_arn | The ARN of an existing alb listener. | Yes | string | Required parameters do not have a default |
 | deregistration_delay | After deregistering a task from the load balancer, the amount of time (seconds) for the load balancer to wait on draining active connections before changing task to unused. | No | Number | 300 | 
-| hostnames | 
+| hostnames | The hostnames for your application. Used by the ALB listener to route traffic. | Yes | list(string) | Required parameters do not have a default. | 
+
 
 Auto Scaling Inputs
 | Name | Description | Required | Type | Default |
@@ -108,6 +125,16 @@ Auto Scaling Inputs
 | memory_target | 
 | memory_scalein_cooldown |
 | memory_scaleout_cooldown | 
+
+Load Balancer Health Check Inputs
+| Name | Description | Required | Type | Default |
+| ---- | ----------- | -------- | ---- | ------- |
+| hc_healthy_threshold |
+| hc_unhealthy_threshold | | 
+| hc_timeout | 
+| hc_interval | 
+| hc_path |
+| hc_matcher | 
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Available outputs from the modules:
 | task_short_name | The task name (cleaned and shortened) used to name resources | 
 
 ### Complete Example
-A complete end-to-end example implementing implementing the shared Fargate Task module with an ECR repository, building the image, etc. for a simple Node.js application can be found in the [NUIT Administrative Systems Fargate Task Example repository](https://github.com/NIT-Administrative-Systems/as-fargate-task-example)
+A complete end-to-end example implementing the shared Fargate Task module with an ECR repository, building the image, etc. for a simple Node.js application can be found in the [NUIT Administrative Systems Fargate Task Example repository](https://github.com/NIT-Administrative-Systems/as-fargate-task-example)
 
 ## Fargate Service
 A service lets you specify how many copies of the task definition to run. This module runs a service behind an Application Load Balancer to distribute incoming traffic to containers (each with 1 task) in your service. Amazon ECS maintains that number of tasks and coordinates task scheduling with the load balancer. The module uses ECS Service Auto Scaling with target tracking to adjust the number of tasks in your service based on CPU and memory utilization targets.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Admin Systems: Fargate Infrastructure-as-Code Modules
 
-```diff
-! When referencing these modules in your IaC module's source, DO NOT reference the master branch as there may be breaking changes from future releases. Only reference a specific release tag, e.g.: ?ref=tags/v1.0.2
-```
+When referencing these modules in your IaC module's source, DO NOT reference the master branch as there may be breaking changes from future releases. Only reference a specific release tag, e.g.: ?ref=tags/v1.0.2
 ```
 module "fargate_example" {
   source = "github.com/NIT-Administrative-Systems/AS-fargate-modules//modules/ecs_fargate_service?ref=tags/v1.0.0"

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Auto Scaling Inputs
 | memory_scalein_cooldown | The minimum time (seconds) after a memory scalein before subsequent memory scalein events. e.g. reduce costs by allowing faster scale in  than the default AWS 300. | No | number | 180 |
 | memory_scaleout_cooldown | The minimum time (seconds) after a memory scaleout before subsequent memory scaleout events. Set at least as long as it takes for your memory load to normalize after scaling out so you don't overscale. | No | number | 180 | 
 
-Load Balancer Health Check Inputs
+Load Balancer Health Check Inputs:
 The load balancer sends periodic requests to the registered tasks to check their status. It will replace unhealthy tasks. 
 | Name | Description | Required | Type | Default |
 | ---- | ----------- | -------- | ---- | ------- |
@@ -139,4 +139,4 @@ The load balancer sends periodic requests to the registered tasks to check their
 
 
 ## Contributing
-Find another input you would like parameterized? Need another output? Pull requests welcome! Want to clarify something in the documentation? Pull requests welcome!
+Find another input you would like parameterized? Need another output? Want to clarify something in the documentation? Pull requests welcome!

--- a/README.md
+++ b/README.md
@@ -59,7 +59,10 @@ A service lets you specify how many copies of the task definition to run. This m
 
 If your service is not a customer-facing application, it is able to make use of the shared account ALB - see the AS Cloud Docs website. 
 
-When `terraform apply` updates the task definition or you push a new ecr image, future tasks launched will use the new image and/or definition but any tasks already running will not recieve the changes. `terraform apply` will not necessarily trigger a redeployment of the ECS service if that resource has not changed; you should develop a mechanism for redeploying the service after image/task definitions are changed, e.g. using `aws ecs update-service --cluster <cluster name> --service <service name> --force-new-deployment` in your pipeline. 
+When `terraform apply` updates the task definition or you push a new ecr image, future tasks launched will use the new image and/or definition but any tasks already running will not recieve the changes. 
+- If your updated image has the same tag as the image used by the currently running task-definition (e.g. "latest"), use the AWS CLI command for redeploying the service after image/task definitions are changed, e.g. using `aws ecs update-service --cluster <cluster name> --service <service name> --force-new-deployment` in a pipeline stage.
+- If your updated image has a different tag, you will have to specify the updated value in the inputs to this module (variable ecr_image_tag), after which a `terraform apply` will create a new task definition (which will cause the service to be recreated). 
+
 
 Fargate service charges are based on the vCPU and Memory resources while your containerized application is running, and the number of tasks running. This is in addition to charges for other AWS services used, such as the ALB traffic.
 
@@ -113,7 +116,6 @@ Application Load Balancer Inputs
 | alb_listener_arn | The ARN of an existing alb listener. | Yes | string | Required parameters do not have a default |
 | deregistration_delay | After deregistering a task from the load balancer, the amount of time (seconds) for the load balancer to wait on draining active connections before changing task to unused. | No | Number | 300 | 
 | hostnames | The hostnames for your application. Used by the ALB listener to route traffic. | Yes | list(string) | Required parameters do not have a default. | 
-
 
 Auto Scaling Inputs
 | Name | Description | Required | Type | Default |

--- a/README.md
+++ b/README.md
@@ -54,9 +54,6 @@ Available outputs from the modules:
 ### Complete Example
 A complete end-to-end example implementing implementing the shared Fargate Task module with an ECR repository, building the image, etc. for a simple Node.js application can be found in the [NUIT Administrative Systems Fargate Task Example repository](https://github.com/NIT-Administrative-Systems/as-fargate-task-example)
 
-### Known issues 
-There is a Terraform or AWS bug causing the task definition template to only update the name property of the secrets and ignore the updated valueFrom in the updated map variable, so valueFrom property doesn't get the new ARN when the container secrets list changes until second deploy. Fixed by adding a depends_on to the task definition template, however the way Terraform handles a depends_on in a template causes it to destroy and recreate  a new task definition revision in the task family every time you run `terraform apply`.
-
 ## Fargate Service
 A service lets you specify how many copies of the task definition to run. This module runs a service behind an Application Load Balancer to distribute incoming traffic to containers (each with 1 task) in your service. Amazon ECS maintains that number of tasks and coordinates task scheduling with the load balancer. The module uses ECS Service Auto Scaling with target tracking to adjust the number of tasks in your service based on CPU and memory utilization targets.
 
@@ -157,9 +154,6 @@ Available outputs from the modules:
 
 ### Complete Example
 A complete end-to-end example implementing implementing the shared Fargate Service module with an ECR repository, building the image, etc. for a simple Node/Express application can be found in the [NUIT Administrative Systems Fargate Service Example repository](https://github.com/NIT-Administrative-Systems/as-fargate-service-example)
-
-### Known issues 
-There is a Terraform or AWS bug causing the task definition template to only update the name property of the secrets and ignore the updated valueFrom in the updated map variable, so valueFrom property doesn't get the new ARN when the container secrets list changes until second deploy. Fixed by adding a depends_on to the task definition template, however the way Terraform handles a depends_on in a template causes it to destroy and recreate  a new task definition revision in the task family every time you run `terraform apply`.
 
 ## Contributing
 Find another input you would like parameterized? Need another output? Want to clarify something in the documentation? Pull requests welcome!

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Admin Systems: Fargate Infrastructure-as-Code Modules
 
+<span style="color:orange">When referencing these modules in your IaC module's source, DO NOT reference the master branch as there may be breaking changes from future releases. Only reference a specific release tag, e.g.: ?ref=tags/v1.0.2</span>
+```
+module "fargate_example" {
+  source = "github.com/NIT-Administrative-Systems/AS-fargate-modules//modules/ecs_fargate_service?ref=tags/v1.0.0"
+```
+
 ## Fargate Task 
 
 This is a Terraform IaC module for creating a fargate task with a single container, which runs on a schedule via cloudwatch event rule, and secrets management through SSM. It implements the Admin Systems practices outlined on our cloud practice site. This solution may be ideal for a serverless architecture which is resource-intensive or long-running enough to exceed the lambda duration/memory limitations e.g. periodic longer-running batch jobs, etc. 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,25 @@ The load balancer sends periodic requests to the registered tasks to check their
 | hc_path | The path for the healthcheck request. | No | string | /healthcheck |
 | hc_matcher | The response code required for a successful health check response. May be a single value, a list of values as a string, or a range of values as a string. | No | string | 200 |
 
+### Outputs
+Available outputs from the modules:
+| Name | Description |
+| ---- | ----------- |
+| parameters | Secret SSM parameters. Output is used by Jenkins to set the secret text. |
+| kms_arn | The arn of the encryption key used for the SSM secrets so you can use it to encrypt elsewhere | 
+| task_definition | The arn of the task definition created. Useful in AWS ECS cli commands e.g. to see if your task is running |  
+| cluster_name | The name of the ecs cluster created. Useful in AWS ECS cli commands  e.g. to run a one-off task or see what's running on your cluster | 
+| security_group | The id of the security group used. May be useful in AWS ECS cli commands, e.g. to run a one-off task | 
+| subnet_ids | The list of subnet ids - may be useful in AWS ECS cli commands e.g. to run a one-off task |
+| cw_log_group_name | The name of the cloudwatch log group created for your task. Useful for querying logs via AWS logs cli |
+| cw_log_stream_prefix | The name of the cloudwatch log prefix for your task logs. Useful for querying logs via AWS logs cli |
+| task_short_name | The task name (cleaned and shortened) used to name resources | 
+
+### Complete Example
+A complete end-to-end example implementing implementing the shared Fargate Service module with an ECR repository, building the image, etc. for a simple Node/Express application can be found in the [NUIT Administrative Systems Fargate Service Example repository](https://github.com/NIT-Administrative-Systems/as-fargate-service-example)
+
+### Known issues 
+There is a Terraform or AWS bug causing the task definition template to only update the name property of the secrets and ignore the updated valueFrom in the updated map variable, so valueFrom property doesn't get the new ARN when the container secrets list changes until second deploy. Fixed by adding a depends_on to the task definition template, however the way Terraform handles a depends_on in a template causes it to destroy and recreate  a new task definition revision in the task family every time you run `terraform apply`.
 
 ## Contributing
 Find another input you would like parameterized? Need another output? Want to clarify something in the documentation? Pull requests welcome!

--- a/README.md
+++ b/README.md
@@ -148,6 +148,18 @@ The load balancer sends periodic requests to the registered tasks to check their
 | hc_path | The path for the healthcheck request. | No | string | /healthcheck |
 | hc_matcher | The response code required for a successful health check response. May be a single value, a list of values as a string, or a range of values as a string. | No | string | 200 |
 
+ECS Service Health Check Inputs:
+The ecs service scheduler may also do health checks. 
+| Name | Description | Required | Type | Default |
+| ---- | ----------- | -------- | ---- | ------- |
+| hc_grace_period | The time (seconds) to wait after the container status is in the RUNNING state before health checks are considered. This prevents prematurely shutting down new tasks as UNHEALTHY when they are known to take awhile to start up after the container is running. | No | number | 30 |
+
+ECS Service Deployment Inputs: 
+| Name | Description | Required | Type | Default |
+| ---- | ----------- | -------- | ---- | ------- |
+| ecs_deploy_min_healthy_perc | The lower limit on how many healthy tasks must remain RUNNING during ECS rolling update deployment. If set to less than 100, enables you ECS to free up cluster capacity before starting new tasks so you can deploy without using additional cluster capacity | No | number | 100 |
+| ecs_deploy_max_perc | The upper limit on how many RUNNING/PENDING/DRAINING tasks there may be during deployment. This controls the deployment batch size; deployment batches may be used to avoid downtime in case a deployment is faulty and fails. | No | number | 200 |
+
 ### Outputs
 Available outputs from the modules:
 | Name | Description |

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This is a Terraform IaC module for creating a fargate task with a single container, which runs on a schedule via cloudwatch event rule, and secrets management through SSM. It implements the Admin Systems practices outlined on our cloud practice site. This solution may be ideal for a serverless architecture which is resource-intensive or long-running enough to exceed the lambda duration/memory limitations e.g. periodic longer-running batch jobs, etc. 
 
+When `terraform apply` updates the task definition, or the image has been updated, future tasks launched will use the new image/definition version but any tasks already running will not recieve the changes. 
+
 Fargate task charges are based on the vCPU and Memory resources while your containerized application is running. 
 
 Examples using this module can be found in the module's examples sub-directory.
@@ -59,6 +61,8 @@ There is a Terraform or AWS bug causing the task definition template to only upd
 A service lets you specify how many copies of the task definition to run. This module runs a service behind an Application Load Balancer to distribute incoming traffic to containers (each with 1 task) in your service. Amazon ECS maintains that number of tasks and coordinates task scheduling with the load balancer. The module uses ECS Service Auto Scaling with target tracking to adjust the number of tasks in your service based on CPU and memory utilization targets.
 
 If your service is not a customer-facing application, it is able to make use of the shared account ALB - see the AS Cloud Docs website. 
+
+When `terraform apply` updates the task definition or you push a new ecr image, future tasks launched will use the new image and/or definition but any tasks already running will not recieve the changes. `terraform apply` will not necessarily trigger a redeployment of the ECS service if that resource has not changed; you should develop a mechanism for redeploying the service after image/task definitions are changed, e.g. using `aws ecs update-service --cluster <cluster name> --service <service name> --force-new-deployment` in your pipeline. 
 
 Fargate service charges are based on the vCPU and Memory resources while your containerized application is running, and the number of tasks running. This is in addition to charges for other AWS services used, such as the ALB traffic.
 

--- a/modules/ecs_fargate_service/alb.tf
+++ b/modules/ecs_fargate_service/alb.tf
@@ -38,12 +38,7 @@ resource "aws_lb_listener_rule" "lb_group_rule" {
     type             = "forward"
     target_group_arn = aws_lb_target_group.lb_target_group.arn
   }
-  
-  # tf 0.12.29 broke this on 7/31
-  # condition {
-  #   field  = "host-header"
-  #   values = var.hostnames
-  #  }
+
   condition {
     host_header {
       values = var.hostnames

--- a/modules/ecs_fargate_service/alb.tf
+++ b/modules/ecs_fargate_service/alb.tf
@@ -1,0 +1,46 @@
+# So TF knows when to re-generate the target group name
+resource "random_id" "target_group_id" {
+  keepers = {
+    name = local.alb_target_group_name
+    vpc_id = var.vpc_id
+    target_type = "ip"
+  }
+  byte_length = 4
+}
+
+# Group of targets (EC2s, Lambdas, Containers, etc) traffic is sent to based on rules
+resource "aws_lb_target_group" "lb_target_group" {
+  name     = "${local.alb_target_group_name}-${random_id.target_group_id.hex}"
+  port     = var.task_listening_port # different than ALB listener port. 
+  protocol = "HTTP"
+  deregistration_delay = var.deregistration_delay
+  target_type = "ip" # If your service's task definition uses awsvpc network mode (required for Fargate launch type), you must choose IP as the target type. This is because tasks that use the awsvpc network mode are associated with an elastic network interface, not an Amazon Elastic Compute Cloud (Amazon EC2) instance.
+  vpc_id = var.vpc_id
+
+  health_check {
+    healthy_threshold = var.hc_healthy_threshold
+    unhealthy_threshold = var.hc_unhealthy_threshold
+    timeout = var.hc_timeout
+    interval = var.hc_interval
+    path = var.hc_path
+    matcher = var.hc_matcher
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_lb_listener_rule" "lb_group_rule" {
+  listener_arn = var.alb_listener_arn
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.lb_target_group.arn
+  }
+  
+  condition {
+    field  = "host-header"
+    values = var.hostnames
+   }
+}

--- a/modules/ecs_fargate_service/alb.tf
+++ b/modules/ecs_fargate_service/alb.tf
@@ -39,8 +39,14 @@ resource "aws_lb_listener_rule" "lb_group_rule" {
     target_group_arn = aws_lb_target_group.lb_target_group.arn
   }
   
+  # tf 0.12.29 broke this on 7/31
+  # condition {
+  #   field  = "host-header"
+  #   values = var.hostnames
+  #  }
   condition {
-    field  = "host-header"
-    values = var.hostnames
-   }
+    host_header {
+      values = var.hostnames
+    }
+  }
 }

--- a/modules/ecs_fargate_service/autoscale.tf
+++ b/modules/ecs_fargate_service/autoscale.tf
@@ -9,7 +9,7 @@ resource "aws_appautoscaling_target" "ecs_target" {
 # Target Tracking - set metric and target value 
 # ECS Auto Scaling creates and manages cloudwatch alarms and calculates scaling adjustment
 resource "aws_appautoscaling_policy" "ecs_targettracking_cpu" {
-  name               = "cpu-gt-75:${aws_appautoscaling_target.ecs_target.resource_id}"
+  name               = "cpu-gt-${var.cpu_target}:${aws_appautoscaling_target.ecs_target.resource_id}"
   policy_type        = "TargetTrackingScaling"
   resource_id        = aws_appautoscaling_target.ecs_target.resource_id
   scalable_dimension = aws_appautoscaling_target.ecs_target.scalable_dimension
@@ -20,16 +20,14 @@ resource "aws_appautoscaling_policy" "ecs_targettracking_cpu" {
       predefined_metric_type = "ECSServiceAverageCPUUtilization"
     }
 
-    target_value = var.cpu_target # scale out when cpu above 75
-    # optional
+    target_value = var.cpu_target
     scale_in_cooldown = var.cpu_scalein_cooldown # time in seconds after a scale_in that it can scale_in again
     scale_out_cooldown = var.cpu_scaleout_cooldown # time in seconds after a scale_out that it can scale_out again
   }
 }
 
-
 resource "aws_appautoscaling_policy" "ecs_targettracking_mem" {
-  name               = "mem-gt-75:${aws_appautoscaling_target.ecs_target.resource_id}"
+  name               = "mem-gt-${var.memory_target}:${aws_appautoscaling_target.ecs_target.resource_id}"
   policy_type        = "TargetTrackingScaling"
   resource_id        = aws_appautoscaling_target.ecs_target.resource_id
   scalable_dimension = aws_appautoscaling_target.ecs_target.scalable_dimension

--- a/modules/ecs_fargate_service/autoscale.tf
+++ b/modules/ecs_fargate_service/autoscale.tf
@@ -1,0 +1,47 @@
+resource "aws_appautoscaling_target" "ecs_target" {
+  service_namespace  = "ecs"
+  resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.main.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  min_capacity       = var.min_capacity
+  max_capacity       = var.max_capacity
+}
+
+# Target Tracking - set metric and target value 
+# ECS Auto Scaling creates and manages cloudwatch alarms and calculates scaling adjustment
+resource "aws_appautoscaling_policy" "ecs_targettracking_cpu" {
+  name               = "cpu-gt-75:${aws_appautoscaling_target.ecs_target.resource_id}"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.ecs_target.resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs_target.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.ecs_target.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+
+    target_value = var.cpu_target # scale out when cpu above 75
+    # optional
+    scale_in_cooldown = var.cpu_scalein_cooldown # time in seconds after a scale_in that it can scale_in again
+    scale_out_cooldown = var.cpu_scaleout_cooldown # time in seconds after a scale_out that it can scale_out again
+  }
+}
+
+
+resource "aws_appautoscaling_policy" "ecs_targettracking_mem" {
+  name               = "mem-gt-75:${aws_appautoscaling_target.ecs_target.resource_id}"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.ecs_target.resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs_target.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.ecs_target.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageMemoryUtilization"
+    }
+
+    target_value = var.memory_target
+    scale_in_cooldown = var.memory_scalein_cooldown # time in seconds after a scale_in that it can scale_in again
+    scale_out_cooldown = var.memory_scaleout_cooldown # time in seconds after a scale_out that it can scale_out again
+  }
+}

--- a/modules/ecs_fargate_service/cw_logs.tf
+++ b/modules/ecs_fargate_service/cw_logs.tf
@@ -1,0 +1,12 @@
+locals {
+    # define reusably so we can refer to it in container defn and outputs
+    cloudwatch_log_group_name = "/aws/ecs/fargate-svc/${local.task_short_name}-${var.env}"
+    cloudwatch_log_stream_prefix = "/task"
+}
+
+resource "aws_cloudwatch_log_group" "ecs" {
+    name              = local.cloudwatch_log_group_name
+    tags              = local.tags
+
+    retention_in_days = 30
+}

--- a/modules/ecs_fargate_service/ecs.tf
+++ b/modules/ecs_fargate_service/ecs.tf
@@ -87,8 +87,8 @@ resource "aws_ecs_service" "main" {
     container_port   = var.task_listening_port
   }
 
-  # Optional: Allow external changes without Terraform plan difference
-  # lifecycle {
-  #   ignore_changes = [desired_count]
-  # }
+  # Optional: Allow external changes without Terraform plan difference - needed so autoscaling not disrupted by terraform apply
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
 }

--- a/modules/ecs_fargate_service/ecs.tf
+++ b/modules/ecs_fargate_service/ecs.tf
@@ -1,0 +1,99 @@
+resource "aws_ecs_cluster" "main" {
+  name = "${local.task_short_name}-${var.env}"
+  tags = local.tags
+}
+
+# format secrets into name/valueFrom pairs for container definition 
+locals {
+  container_ssm_secrets_list = [
+    for k,v in local.container_ssm_map: 
+      {"name":"${k}", "valueFrom":"${v}"}
+  ]
+}
+
+data "template_file" "fargate_container_definition" {
+  depends_on = [aws_ssm_parameter.secure_param]
+  template      = <<EOF
+  [
+    {
+      "name": "${local.task_short_name}-${var.env}",
+      "image": "${var.ecr_repository_url}:${var.ecr_image_tag}",
+      "requiresCompatibilities": [
+        "FARGATE"
+     ],
+      "networkMode": "awsvpc",
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-stream-prefix": "${local.cloudwatch_log_stream_prefix}",
+          "awslogs-region": "${var.region}",
+          "awslogs-group": "${local.cloudwatch_log_group_name}"
+        }
+      },
+      "environment": ${jsonencode(var.container_env_variables)},
+      "secrets": ${jsonencode(local.container_ssm_secrets_list)},
+      "portMappings": ${jsonencode(var.container_port_mappings)}
+    }
+  ]
+  EOF
+}
+
+resource "aws_ecs_task_definition" "main" {
+  depends_on = [
+      aws_iam_role.ecs_execution_role,
+      aws_iam_role.ecs_task_role
+  ]
+
+  family = var.task_family != null ? var.task_family : "${local.task_short_name}-${var.env}"
+
+  # define the containers that are launched as part of a task
+  container_definitions    = data.template_file.fargate_container_definition.rendered
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.task_cpu
+  memory                   = var.task_memory
+  execution_role_arn       = aws_iam_role.ecs_execution_role.arn
+  task_role_arn            = aws_iam_role.ecs_task_role.arn
+
+  tags = local.tags
+}
+
+resource "aws_ecs_service" "main" {
+  # depends_on      = ["aws_iam_role_policy.foo"]
+
+  name            = "${local.task_short_name}-${var.env}"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.main.arn
+  # iam_role        = aws_iam_role.foo.arn
+  launch_type     = "FARGATE"
+  desired_count   = 2 # number of instances to start with 
+
+  network_configuration {
+    subnets         = var.subnet_ids
+    security_groups = [var.aws_security_group != null ? var.aws_security_group.id : aws_security_group.allow_outbound[0].id]
+    assign_public_ip = var.assign_public_ip
+  }
+
+  depends_on = [
+    aws_iam_role.ecs_task_role,
+    aws_iam_role.ecs_execution_role,
+    aws_cloudwatch_log_group.ecs,
+  ]
+
+  # ordered_placement_strategy {
+  #   type  = "binpack"
+  #   field = "cpu"
+  # }
+
+  # register the service with the load balancer target group created 
+  load_balancer {
+    target_group_arn = aws_lb_target_group.lb_target_group.arn
+    container_name   = "${local.task_short_name}-${var.env}" # as it appears in container definition 
+    container_port   = var.task_listening_port
+  }
+
+  # Optional: Allow external changes without Terraform plan difference
+  # lifecycle {
+  #   ignore_changes = [desired_count]
+  # }
+}

--- a/modules/ecs_fargate_service/ecs.tf
+++ b/modules/ecs_fargate_service/ecs.tf
@@ -63,6 +63,11 @@ resource "aws_ecs_service" "main" {
   launch_type     = "FARGATE"
   desired_count   = 2 # number of instances to start with on new deployment 
 
+  # container health and rolling deployments
+  deployment_minimum_healthy_percent = var.ecs_deploy_min_healthy_perc
+  deployment_maximum_percent = var.ecs_deploy_max_perc
+  health_check_grace_period_seconds = var.hc_grace_period
+
   network_configuration {
     subnets         = var.subnet_ids
     security_groups = [var.aws_security_group != null ? var.aws_security_group.id : aws_security_group.allow_outbound[0].id]

--- a/modules/ecs_fargate_service/ecs.tf
+++ b/modules/ecs_fargate_service/ecs.tf
@@ -61,7 +61,7 @@ resource "aws_ecs_service" "main" {
   cluster         = aws_ecs_cluster.main.id
   task_definition = aws_ecs_task_definition.main.arn
   launch_type     = "FARGATE"
-  desired_count   = 2 # number of instances to start with on new deployment 
+  desired_count   = var.desired_count # number of instances to start with on new deployment 
 
   # container health and rolling deployments
   deployment_minimum_healthy_percent = var.ecs_deploy_min_healthy_perc

--- a/modules/ecs_fargate_service/ecs.tf
+++ b/modules/ecs_fargate_service/ecs.tf
@@ -80,11 +80,6 @@ resource "aws_ecs_service" "main" {
     aws_cloudwatch_log_group.ecs,
   ]
 
-  # ordered_placement_strategy {
-  #   type  = "binpack"
-  #   field = "cpu"
-  # }
-
   # register the service with the load balancer target group created 
   load_balancer {
     target_group_arn = aws_lb_target_group.lb_target_group.arn

--- a/modules/ecs_fargate_service/ecs.tf
+++ b/modules/ecs_fargate_service/ecs.tf
@@ -56,7 +56,7 @@ resource "aws_ecs_task_definition" "main" {
   tags = local.tags
 }
 
-resource "aws_ecs_service" "main" {u
+resource "aws_ecs_service" "main" {
   name            = "${local.task_short_name}-${var.env}"
   cluster         = aws_ecs_cluster.main.id
   task_definition = aws_ecs_task_definition.main.arn

--- a/modules/ecs_fargate_service/ecs.tf
+++ b/modules/ecs_fargate_service/ecs.tf
@@ -63,10 +63,6 @@ resource "aws_ecs_service" "main" {u
   launch_type     = "FARGATE"
   desired_count   = 2 # number of instances to start with on new deployment 
 
-  # used by service scheduler when you update-service --force-new-deployment after pushing a new application image:
-  deployment_minimum_healthy_percent = var.ecs_deploy_min_healthy_perc˜
-  deployment_maximum_percent         = var.ecs_deploy_max_perc˜
-
   network_configuration {
     subnets         = var.subnet_ids
     security_groups = [var.aws_security_group != null ? var.aws_security_group.id : aws_security_group.allow_outbound[0].id]

--- a/modules/ecs_fargate_service/ecs.tf
+++ b/modules/ecs_fargate_service/ecs.tf
@@ -5,15 +5,24 @@ resource "aws_ecs_cluster" "main" {
 
 # format secrets into name/valueFrom pairs for container definition 
 locals {
+  container_ssm_map = zipmap(var.container_secrets, slice(aws_ssm_parameter.secure_param.*.arn, 0, length(var.container_secrets)))
   container_ssm_secrets_list = [
     for k,v in local.container_ssm_map: 
       {"name":"${k}", "valueFrom":"${v}"}
   ]
 }
 
-data "template_file" "fargate_container_definition" {
-  depends_on = [aws_ssm_parameter.secure_param]
-  template      = <<EOF
+resource "aws_ecs_task_definition" "main" {
+  depends_on = [
+      aws_iam_role.ecs_execution_role,
+      aws_iam_role.ecs_task_role,
+  ]
+
+  family = var.task_family != null ? var.task_family : "${local.task_short_name}-${var.env}"
+
+  # define the containers that are launched as part of a task
+  # don't put this json as a separate template file data object bc uses a different provider and the order gets odd and doesn't get the updated valueFrom in the secrets map in time to update it in the task definition. 
+  container_definitions    = <<EOF
   [
     {
       "name": "${local.task_short_name}-${var.env}",
@@ -36,18 +45,7 @@ data "template_file" "fargate_container_definition" {
     }
   ]
   EOF
-}
-
-resource "aws_ecs_task_definition" "main" {
-  depends_on = [
-      aws_iam_role.ecs_execution_role,
-      aws_iam_role.ecs_task_role
-  ]
-
-  family = var.task_family != null ? var.task_family : "${local.task_short_name}-${var.env}"
-
-  # define the containers that are launched as part of a task
-  container_definitions    = data.template_file.fargate_container_definition.rendered
+  
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.task_cpu

--- a/modules/ecs_fargate_service/ecs.tf
+++ b/modules/ecs_fargate_service/ecs.tf
@@ -56,15 +56,16 @@ resource "aws_ecs_task_definition" "main" {
   tags = local.tags
 }
 
-resource "aws_ecs_service" "main" {
-  # depends_on      = ["aws_iam_role_policy.foo"]
-
+resource "aws_ecs_service" "main" {u
   name            = "${local.task_short_name}-${var.env}"
   cluster         = aws_ecs_cluster.main.id
   task_definition = aws_ecs_task_definition.main.arn
-  # iam_role        = aws_iam_role.foo.arn
   launch_type     = "FARGATE"
-  desired_count   = 2 # number of instances to start with 
+  desired_count   = 2 # number of instances to start with on new deployment 
+
+  # used by service scheduler when you update-service --force-new-deployment after pushing a new application image:
+  deployment_minimum_healthy_percent = var.ecs_deploy_min_healthy_perc˜
+  deployment_maximum_percent         = var.ecs_deploy_max_perc˜
 
   network_configuration {
     subnets         = var.subnet_ids

--- a/modules/ecs_fargate_service/examples/iac-ecs/dev/main.tf
+++ b/modules/ecs_fargate_service/examples/iac-ecs/dev/main.tf
@@ -1,0 +1,17 @@
+module "fargate_resources" {
+    source = "../modules"
+
+    environment = "dev"
+
+    account_resources_state_bucket  = "as-ado-sbx-tfstate"
+    account_resources_state_file    = "as-ado-sbx-resources/sandbox/terraform.tfstate"
+    account_resources_state_region  = "us-east-2"
+
+    alb_state_bucket = "as-ado-sbx-tfstate"
+    alb_state_file   = "as-fargate-service-example/alb/dev/terraform.tfstate"
+    alb_state_region = "us-east-2"
+
+    ecr_state_bucket  = "as-ado-sbx-tfstate"
+    ecr_state_file    = "as-fargate-service-example/ecr/dev/terraform.tfstate"
+    ecr_state_region  = "us-east-2"
+}

--- a/modules/ecs_fargate_service/examples/iac-ecs/dev/outputs.tf
+++ b/modules/ecs_fargate_service/examples/iac-ecs/dev/outputs.tf
@@ -1,0 +1,3 @@
+output "parameters" {
+    value = module.fargate_resources.parameters
+}

--- a/modules/ecs_fargate_service/examples/iac-ecs/dev/state.tf
+++ b/modules/ecs_fargate_service/examples/iac-ecs/dev/state.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket = "as-ado-sbx-tfstate"
+    key    = "example-ecs-service/dev/terraform.tfstate"
+    region = "us-east-2"
+  }
+}
+

--- a/modules/ecs_fargate_service/examples/iac-ecs/modules/data_for_fargate_service.tf
+++ b/modules/ecs_fargate_service/examples/iac-ecs/modules/data_for_fargate_service.tf
@@ -1,0 +1,33 @@
+# Shared resources for the AWS account
+# Used to get the VPC ID & subnet IDs that have been allocated for us
+# Need the VPC ID
+data "terraform_remote_state" "account_resources" {
+  backend = "s3"
+
+  config = {
+    bucket = var.account_resources_state_bucket
+    key    = var.account_resources_state_file
+    region = var.account_resources_state_region
+  }
+}
+
+# For the listener ARN
+data "terraform_remote_state" "alb_listener" {
+  backend = "s3"
+
+  config = {
+    bucket = var.alb_state_bucket
+    key    = var.alb_state_file
+    region = var.alb_state_region
+  }
+}
+
+data "terraform_remote_state" "ecr" {
+  backend = "s3"
+
+  config = {
+    bucket = var.ecr_state_bucket
+    key    = var.ecr_state_file
+    region = var.ecr_state_region
+  }
+}

--- a/modules/ecs_fargate_service/examples/iac-ecs/modules/fargate_service.tf
+++ b/modules/ecs_fargate_service/examples/iac-ecs/modules/fargate_service.tf
@@ -1,0 +1,68 @@
+# Build the shared module infrastructure
+module "fargate_task" {
+  source = "github.com/NIT-Administrative-Systems/AS-fargate-modules//modules/ecs_fargate_service?ref=master"
+
+  env         = var.environment
+  task_name   = var.app_name
+  region      = var.region
+
+  ecr_repository_url = data.terraform_remote_state.ecr.outputs.ecr_repository_url
+  ecr_repository_arn = data.terraform_remote_state.ecr.outputs.ecr_repository_arn
+
+  alb_listener_arn = data.terraform_remote_state.alb_listener.outputs.alb_listener_arn
+  hostnames = data.terraform_remote_state.alb_listener.outputs.domain_names
+
+  vpc_id     = data.terraform_remote_state.account_resources.outputs.vpc_id
+  subnet_ids = data.terraform_remote_state.account_resources.outputs.private_subnet_ids
+  alb_security_group_id = data.terraform_remote_state.account_resources.outputs.lb_security_group_id
+
+  # Do not include secret values (passwords, API tokens, etc)
+  # list of maps e.g. [{name = "test12", env = "dev"}]
+  container_env_variables = [
+    { 
+      name = "task_name",
+      value = var.app_name
+    },
+    {
+      name = "env",
+      value = var.environment
+    },
+    {
+      name = "NODE_ENV",
+      value = "production"
+    },
+    {
+      name = "NODE_OPTIONS",
+      value = "--max-old-space-size=500"
+    }
+  ]
+
+  /*
+  * List of SSM Parameters to create for secrets
+  * These names should match the Jenkins credential IDs. 
+  * SSM values will be injected into container when it starts up and available as environment variables 
+  * These names will match the name of the env variable in the container
+  * Do not use dashes/hyphens in these names because they can't be set as environment variables
+  */
+  container_secrets = ["my_secret_password", "test_123"]
+
+  container_port_mappings = [
+    { 
+      containerPort = 8080, 
+      protocol = "tcp",
+      hostPort = 8080 # must match containerPort for awsvpc mode (which is required for FARGATE launch type)
+    }
+  ]
+
+  tags = {
+    test_tag = "testtag-1234" # add a supplemental tag 
+    Application = "myapp" # override the default Application tag value 
+  }
+
+  deregistration_delay = 45
+
+  # auto scaling
+  min_capacity = 1
+  max_capacity = 4
+
+}

--- a/modules/ecs_fargate_service/examples/iac-ecs/modules/outputs.tf
+++ b/modules/ecs_fargate_service/examples/iac-ecs/modules/outputs.tf
@@ -1,0 +1,3 @@
+output "parameters" {
+    value = module.fargate_task.parameters
+}

--- a/modules/ecs_fargate_service/examples/iac-ecs/modules/provider.tf
+++ b/modules/ecs_fargate_service/examples/iac-ecs/modules/provider.tf
@@ -1,0 +1,4 @@
+# Specify the provider and access details
+provider "aws" {
+  region     = var.region
+}

--- a/modules/ecs_fargate_service/examples/iac-ecs/modules/s3.tf
+++ b/modules/ecs_fargate_service/examples/iac-ecs/modules/s3.tf
@@ -1,0 +1,9 @@
+# This is just an example of other resources you might be building outside the shared module
+# For which you can give IAM permissions to the fargate tasks as needed
+resource "aws_s3_bucket" "example" {
+  bucket = "${var.app_name}-example-bucket-${var.environment}"
+  acl    = "private"
+
+  tags = local.tags
+}
+

--- a/modules/ecs_fargate_service/examples/iac-ecs/modules/tags.tf
+++ b/modules/ecs_fargate_service/examples/iac-ecs/modules/tags.tf
@@ -1,0 +1,6 @@
+locals {
+    tags = {
+        Application = var.app_name
+        Env = var.environment
+    }
+}

--- a/modules/ecs_fargate_service/examples/iac-ecs/modules/variables.tf
+++ b/modules/ecs_fargate_service/examples/iac-ecs/modules/variables.tf
@@ -1,0 +1,54 @@
+variable "environment" {
+  description = "Environment that this app is runnig for, e.g. dev/qa/prod"
+}
+
+variable "region" {
+  default = "us-east-2"
+}
+
+variable "app_name" {
+  default = "as-fargate-service-example"
+}
+
+variable "account_resources_state_bucket" {
+  description = "State bucket for shared account resources"
+}
+
+variable "account_resources_state_file" {
+  description = "State file for shared account resources"
+}
+
+variable "account_resources_state_region" {
+  description = "State region for shared account resources"
+
+  default = "us-east-2"
+}
+
+variable "alb_state_bucket" {
+  description = "State bucket for account alb resources"
+}
+
+variable "alb_state_file" {
+  description = "State file for account alb resources"
+}
+
+variable "alb_state_region" {
+  description = "State region for account alb resources"
+
+  default = "us-east-2"
+}
+
+variable "ecr_state_bucket" {
+  description = "State bucket for ECR resources"
+}
+
+variable "ecr_state_file" {
+  description = "State file for ECR resources"
+}
+
+variable "ecr_state_region" {
+  description = "State region for ECR resources"
+
+  default = "us-east-2"
+}
+

--- a/modules/ecs_fargate_service/iam_ecs_execution.tf
+++ b/modules/ecs_fargate_service/iam_ecs_execution.tf
@@ -88,22 +88,3 @@ resource "aws_iam_role_policy" "ecs_execution_secrets_policy" {
     role    = aws_iam_role.ecs_execution_role.id
     policy  = data.aws_iam_policy_document.ecs_inject_container_secrets_policy[0].json # there will only be 1
 }
-
-data "aws_iam_policy_document" "task_alb_policy" {
-  statement {
-    effect = "Allow"
-    actions = [
-      "elasticloadbalancing:DeregisterTargets",
-      "elasticloadbalancing:Describe*",
-      "elasticloadbalancing:RegisterTargets",
-    ]
-    resources = ["*"]
-  }
-}
-
-resource "aws_iam_role_policy" "alb_role_policy" {
-    name    = "${local.task_short_name}-alb-role-policy-${var.env}"
-    role    = aws_iam_role.ecs_execution_role.id
-    policy  = data.aws_iam_policy_document.task_alb_policy.json
-}
-

--- a/modules/ecs_fargate_service/iam_ecs_execution.tf
+++ b/modules/ecs_fargate_service/iam_ecs_execution.tf
@@ -65,6 +65,10 @@ data "aws_iam_policy_document" "ecs_execution_container_policy" {
 }
 
 data "aws_iam_policy_document" "ecs_inject_container_secrets_policy" {
+  depends_on = [
+      aws_ssm_parameter.secure_param # otherwise doesn't get updated params until second apply
+  ]
+
   count = length(var.container_secrets) > 0 ? 1 : 0 # can only add this policy if there are ssm params 
   
   statement {

--- a/modules/ecs_fargate_service/iam_ecs_execution.tf
+++ b/modules/ecs_fargate_service/iam_ecs_execution.tf
@@ -1,0 +1,109 @@
+# role for the container - get ecr image etc.
+data "aws_iam_policy_document" "ecs_execution_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ecs_execution_role" {
+  name                  = "${local.task_short_name}-ecs-execution-role-${var.env}"
+  assume_role_policy    = data.aws_iam_policy_document.ecs_execution_assume_role_policy.json
+  description           = "${local.task_short_name} - ECS Execution Role - ${var.env}"
+  tags                  = local.tags
+}
+
+data "aws_iam_policy_document" "ecs_execution_container_policy" {
+    depends_on = [aws_ssm_parameter.secure_param]
+
+    statement {
+        actions = [
+            "ecr:GetAuthorizationToken",
+            "ecr:BatchCheckLayerAvailability",
+            "ecr:GetDownloadUrlForLayer",
+            "ecr:BatchGetImage",
+        ]
+
+        resources = [
+            var.ecr_repository_arn
+        ]
+    }
+
+    statement {
+        actions = [
+            "ecr:GetAuthorizationToken",
+        ]
+
+        resources = [
+            "*"
+        ]
+    }
+
+    statement {
+        actions = [
+            "logs:*"
+        ]
+
+        resources = [
+            "*"
+        ]
+    }
+
+    statement {
+        actions = [
+            "kms:Decrypt"
+        ]
+
+        resources = [
+            aws_kms_key.key.arn
+        ]
+    }
+}
+
+data "aws_iam_policy_document" "ecs_inject_container_secrets_policy" {
+  count = length(var.container_secrets) > 0 ? 1 : 0 # can only add this policy if there are ssm params 
+  
+  statement {
+      actions = [
+          "ssm:GetParameters"
+      ]
+      
+      resources = aws_ssm_parameter.secure_param[*].arn
+  }
+}
+
+resource "aws_iam_role_policy" "ecs_execution_role_policy" {
+    name    = "${local.task_short_name}-ecs-execution-role-policy-${var.env}"
+    role    = aws_iam_role.ecs_execution_role.id
+    policy  = data.aws_iam_policy_document.ecs_execution_container_policy.json
+}
+
+resource "aws_iam_role_policy" "ecs_execution_secrets_policy" {
+    count = length(var.container_secrets) > 0 ? 1 : 0 # can only add this role policy if there are ssm params 
+    name    = "${local.task_short_name}-ecs-execution-secrets-policy-${var.env}"
+    role    = aws_iam_role.ecs_execution_role.id
+    policy  = data.aws_iam_policy_document.ecs_inject_container_secrets_policy[0].json # there will only be 1
+}
+
+data "aws_iam_policy_document" "task_alb_policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "elasticloadbalancing:DeregisterTargets",
+      "elasticloadbalancing:Describe*",
+      "elasticloadbalancing:RegisterTargets",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "alb_role_policy" {
+    name    = "${local.task_short_name}-alb-role-policy-${var.env}"
+    role    = aws_iam_role.ecs_execution_role.id
+    policy  = data.aws_iam_policy_document.task_alb_policy.json
+}
+

--- a/modules/ecs_fargate_service/iam_ecs_task.tf
+++ b/modules/ecs_fargate_service/iam_ecs_task.tf
@@ -1,0 +1,27 @@
+# create a policy from the document passed in
+resource "aws_iam_role_policy" "task_role_policy" {
+    count = var.aws_task_iam_policy_document != null ? 1 : 0 # only create if a policy document is provided 
+
+    name    = "${local.task_short_name}-task-role-policy-${var.env}"
+    role    = aws_iam_role.ecs_task_role.id
+    policy  = var.aws_task_iam_policy_document.json
+}
+
+# allow the task to assume the role
+data "aws_iam_policy_document" "task_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ecs_task_role" {
+  name                  = "${local.task_short_name}-task-role-${var.env}"
+  assume_role_policy    = data.aws_iam_policy_document.task_assume_role_policy.json
+  description           = "${local.task_short_name} - ECS Task Role - ${var.env}"
+  tags                  = local.tags
+}

--- a/modules/ecs_fargate_service/locals.tf
+++ b/modules/ecs_fargate_service/locals.tf
@@ -1,0 +1,13 @@
+locals {
+    # Credit to Nick Evans:
+    # https://github.com/NIT-Administrative-Systems/AS-serverless-api-IaC/blob/develop/locals.tf#L6
+
+    # Remove any unaccaptable chars since we'll be using this for resource name
+    clean_task_name = lower(replace(var.task_name, "/[^A-Za-z0-9_-]/", "-"))
+
+    # Keep the task name shorter so we can be sure {task name}-{env} fits in all the resource names.
+    task_short_name = "${substr(local.clean_task_name, 0, max(length(local.clean_task_name), 40))}"
+
+    # keep ALB target group name under 32 characters
+    alb_target_group_name = "${substr(local.clean_task_name, 0, 12)}-${var.env}"
+}

--- a/modules/ecs_fargate_service/network.tf
+++ b/modules/ecs_fargate_service/network.tf
@@ -11,7 +11,7 @@ resource "aws_security_group" "allow_outbound" {
     from_port       = var.task_listening_port
     to_port         = var.task_listening_port
     protocol        = "tcp"
-    security_groups = [var.account_lb_security_group_id]
+    security_groups = [var.alb_security_group_id]
   }
 
   # for testing - add public ip address, public subnets, and inbound access from my ip

--- a/modules/ecs_fargate_service/network.tf
+++ b/modules/ecs_fargate_service/network.tf
@@ -1,0 +1,32 @@
+# Traffic to/from the ECS Cluster
+resource "aws_security_group" "allow_outbound" {
+  count = var.aws_security_group != null ? 0 : 1 # only create if a security group resource is not provided as an input
+
+  name        = "${local.task_short_name}-${var.env}"
+  description = "sg for ${local.task_short_name} ECS cluster outbound traffic - ${var.env}"
+  vpc_id      = var.vpc_id
+  tags        = local.tags
+
+  ingress {
+    from_port       = var.task_listening_port
+    to_port         = var.task_listening_port
+    protocol        = "tcp"
+    security_groups = [var.account_lb_security_group_id]
+  }
+
+  # for testing - add public ip address, public subnets, and inbound access from my ip
+  # ingress {
+  #   from_port = 8080
+  #   to_port = 8080
+  #   protocol = "tcp"
+  #   cidr_blocks = ["24.12.65.162/32"]
+  # }
+
+  # outbound traffic needed for NAT Gateway and outside API calls
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1" # equivalent of ALL which is not allowed here
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/modules/ecs_fargate_service/outputs.tf
+++ b/modules/ecs_fargate_service/outputs.tf
@@ -6,6 +6,10 @@ output "task_definition" {
   value = aws_ecs_task_definition.main.arn
 }
 
+output "ecs_service_name" {
+  value = aws_ecs_service.ecs_task_serv.name
+}
+
 output "subnet_ids" {
   value = var.subnet_ids
 }

--- a/modules/ecs_fargate_service/outputs.tf
+++ b/modules/ecs_fargate_service/outputs.tf
@@ -1,0 +1,35 @@
+output "cluster_name" {
+  value = aws_ecs_cluster.main.arn
+}
+
+output "task_definition" {
+  value = aws_ecs_task_definition.main.arn
+}
+
+output "subnet_ids" {
+  value = var.subnet_ids
+}
+
+output "security_group" {
+  value = var.aws_security_group != null ? var.aws_security_group.id : aws_security_group.allow_outbound[0].id
+}
+
+output "task_short_name" {
+    value = local.task_short_name
+}
+
+output "cw_log_group_name" {
+    value = local.cloudwatch_log_group_name
+}
+
+output "cw_log_stream_prefix" {
+    value = local.cloudwatch_log_stream_prefix
+}
+
+output "parameters" {
+    value = zipmap(var.container_secrets, slice(aws_ssm_parameter.secure_param.*.name, 0, length(var.container_secrets)))
+}
+
+output "kms_arn" {
+    value = aws_kms_key.key.arn
+}

--- a/modules/ecs_fargate_service/outputs.tf
+++ b/modules/ecs_fargate_service/outputs.tf
@@ -7,7 +7,7 @@ output "task_definition" {
 }
 
 output "service_name" {
-  value = aws_ecs_service.ecs_task_serv.name
+  value = aws_ecs_service.main.name
 }
 
 output "subnet_ids" {

--- a/modules/ecs_fargate_service/outputs.tf
+++ b/modules/ecs_fargate_service/outputs.tf
@@ -6,7 +6,7 @@ output "task_definition" {
   value = aws_ecs_task_definition.main.arn
 }
 
-output "ecs_service_name" {
+output "service_name" {
   value = aws_ecs_service.ecs_task_serv.name
 }
 

--- a/modules/ecs_fargate_service/provider.tf
+++ b/modules/ecs_fargate_service/provider.tf
@@ -1,0 +1,4 @@
+# Specify the provider and access details
+provider "aws" {
+  region     = var.region
+}

--- a/modules/ecs_fargate_service/ssm.tf
+++ b/modules/ecs_fargate_service/ssm.tf
@@ -1,0 +1,27 @@
+
+resource "aws_kms_key" "key" {
+  description = "Key for encrypting ${local.task_short_name} secrets - ${var.env}"
+}
+
+resource "aws_ssm_parameter" "secure_param" {
+  count = length(var.container_secrets)
+
+  name        = "/${local.task_short_name}/${var.env}/${var.container_secrets[count.index]}"
+  description = "Fargate Task secret: ${var.container_secrets[count.index]}"
+  type        = "SecureString"
+  value       = "SSM parameter store not populated from Jenkins"
+  key_id      = aws_kms_key.key.arn
+
+  # The parameter will be created with a dummy value. Jenkins will update it with 
+  # the final value in a subsequent pipeline step.
+  #
+  # TF will not override the parameter once it has been created.
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+# create secrets map for ecs task definition
+locals {
+    container_ssm_map = zipmap(var.container_secrets, slice(aws_ssm_parameter.secure_param.*.arn, 0, length(var.container_secrets)))
+}

--- a/modules/ecs_fargate_service/ssm.tf
+++ b/modules/ecs_fargate_service/ssm.tf
@@ -20,8 +20,3 @@ resource "aws_ssm_parameter" "secure_param" {
     ignore_changes = [value]
   }
 }
-
-# create secrets map for ecs task definition
-locals {
-    container_ssm_map = zipmap(var.container_secrets, slice(aws_ssm_parameter.secure_param.*.arn, 0, length(var.container_secrets)))
-}

--- a/modules/ecs_fargate_service/tags.tf
+++ b/modules/ecs_fargate_service/tags.tf
@@ -1,0 +1,8 @@
+locals {
+    as_standard_tags = {
+        Application = var.task_name
+        Environment = var.env
+    }
+
+    tags = merge(local.as_standard_tags, var.tags)     # if tags of the same name are specified in the user's map it will just overwrite with the last value specified. 
+}

--- a/modules/ecs_fargate_service/variables.tf
+++ b/modules/ecs_fargate_service/variables.tf
@@ -1,0 +1,136 @@
+variable "env" {}
+variable "task_name" {}
+variable "region" {}
+
+# Fargate Task
+variable "task_cpu" {
+    type = number
+    default = 256
+}
+variable "task_memory" {
+    type = number 
+    default = 512
+}
+variable "aws_task_iam_policy_document" {
+    default = null # mark as unset if there is none provided
+}
+variable "task_count" {
+    type = number
+    default = 1
+}
+variable "task_family" {
+    type = string
+    default = null # defaults to unset and will be generated in the task definition from other vars
+}
+# Container Definition
+variable "container_env_variables" {
+    type = list(object({
+        name  = string
+        value = string
+    }))
+    default = []
+}
+variable "container_secrets" {
+    type = list(string)
+    default = []
+}
+variable "container_port_mappings" {
+    type = list(object({
+        containerPort = number
+        hostPort      = number
+        protocol      = string
+    }))
+    default = []
+}
+
+# Task Networking
+variable "vpc_id" {}
+variable "subnet_ids" {
+    type = list(string)
+}
+variable "assign_public_ip" {
+    type = bool
+    default = false
+}
+variable "aws_security_group" {
+    default = null # mark as unset if there is none provided
+}
+variable "account_lb_security_group_id" {}
+variable "task_listening_port" {
+    type = number
+    default = 8080
+}
+
+# ECR
+variable "ecr_repository_url"{}
+variable "ecr_repository_arn" {}
+variable "ecr_image_tag" {
+    type = string
+    default = "latest"
+}
+
+variable "tags" {
+    type = map(string)
+    default = {}
+}
+
+# ALB
+variable "deregistration_delay" {}
+variable "alb_listener_arn" {}
+variable "hostnames" {
+    type = list(string)
+}
+
+# Auto Scaling
+variable "min_capacity" {}
+variable "max_capacity" {}
+variable "cpu_target" {
+    type = number
+    default = 75
+}
+variable "memory_target" {
+    type = number
+    default = 75
+}
+variable "cpu_scalein_cooldown" {
+    type = number
+    default = 180 # reduce costs by allowing the group to scale in faster than aws 300 default
+}
+variable "cpu_scaleout_cooldown" {
+    type = number
+    default = 180
+}
+variable "memory_scalein_cooldown" {
+    type = number
+    default = 180 # reduce costs by allowing the group to scale in faster than aws 300 default
+}
+variable "memory_scaleout_cooldown" {
+    type = number
+    default = 180
+}
+
+# LB Health Check
+variable "hc_healthy_threshold" {
+    type = number
+    default = 4
+}
+variable "hc_unhealthy_threshold" {
+    type = number
+    default = 2
+}
+variable "hc_timeout" {
+    type = number
+    default = 15
+}
+variable "hc_interval" {
+    type = number
+    default = 60
+}
+variable "hc_path" {
+    type = string
+    default = "/healthcheck"
+}
+variable "hc_matcher" {
+    type = string
+    default = "200"
+}

--- a/modules/ecs_fargate_service/variables.tf
+++ b/modules/ecs_fargate_service/variables.tf
@@ -137,3 +137,17 @@ variable "hc_matcher" {
     type = string
     default = "200"
 }
+variable "hc_grace_period" {
+    type = number
+    default = 30
+}
+
+# ECS Deploy
+variable "ecs_deploy_min_healthy_perc" {
+ type = number
+ default = 100
+}
+variable "ecs_deploy_max_perc" {
+ type = number
+ default = 200
+}

--- a/modules/ecs_fargate_service/variables.tf
+++ b/modules/ecs_fargate_service/variables.tf
@@ -75,7 +75,10 @@ variable "tags" {
 }
 
 # ALB
-variable "deregistration_delay" {}
+variable "deregistration_delay" {
+    type = number
+    default = 300
+}
 variable "alb_listener_arn" {}
 variable "hostnames" {
     type = list(string)

--- a/modules/ecs_fargate_service/variables.tf
+++ b/modules/ecs_fargate_service/variables.tf
@@ -55,7 +55,7 @@ variable "assign_public_ip" {
 variable "aws_security_group" {
     default = null # mark as unset if there is none provided
 }
-variable "account_lb_security_group_id" {}
+variable "alb_security_group_id" {}
 variable "task_listening_port" {
     type = number
     default = 8080

--- a/modules/ecs_fargate_task/ecs.tf
+++ b/modules/ecs_fargate_task/ecs.tf
@@ -5,15 +5,25 @@ resource "aws_ecs_cluster" "main" {
 
 # format secrets into name/valueFrom pairs for container definition 
 locals {
+  container_ssm_map = zipmap(var.container_secrets, slice(aws_ssm_parameter.secure_param.*.arn, 0, length(var.container_secrets)))
   container_ssm_secrets_list = [
     for k,v in local.container_ssm_map: 
       {"name":"${k}", "valueFrom":"${v}"}
   ]
 }
 
-data "template_file" "fargate_container_definition" {
-  depends_on = [aws_ssm_parameter.secure_param]
-  template      = <<EOF
+resource "aws_ecs_task_definition" "main" {
+  depends_on = [
+      aws_iam_role.ecs_execution_role,
+      aws_iam_role.ecs_task_role
+  ]
+
+  family = var.task_family != null ? var.task_family : "${local.task_short_name}-${var.env}"
+
+  # define the containers that are launched as part of a task
+  # must be inline and not template_file or the dependencies are messed up because it uses another provider
+  # in that case, valueFrom doesn't get updated in the secrets map until the second apply because order of execution is incorrect
+  container_definitions    = <<EOF
   [
     {
       "name": "${local.task_short_name}",
@@ -36,18 +46,7 @@ data "template_file" "fargate_container_definition" {
     }
   ]
   EOF
-}
-
-resource "aws_ecs_task_definition" "main" {
-  depends_on = [
-      aws_iam_role.ecs_execution_role,
-      aws_iam_role.ecs_task_role
-  ]
-
-  family = var.task_family != null ? var.task_family : "${local.task_short_name}-${var.env}"
-
-  # define the containers that are launched as part of a task
-  container_definitions    = data.template_file.fargate_container_definition.rendered
+  
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.task_cpu

--- a/modules/ecs_fargate_task/examples/iac-ecs_all-vars/modules/fargate_task.tf
+++ b/modules/ecs_fargate_task/examples/iac-ecs_all-vars/modules/fargate_task.tf
@@ -23,7 +23,7 @@ module "fargate_task" {
   assign_public_ip = true
 
   cw_status   = true # rule enabled (true) or disabled (false)
-  cw_schedule = "cron(30 21 ? * MON-FRI *)" # cloudwatch schedule to use when DST is true 
+  cw_schedule = "cron(30 21 ? * MON-FRI *)"
 
   # Do not include secret values here (passwords, API tokens, etc)
   # List of maps e.g. [{name = "env", value = "dev"}, {name = "task_name", value = "my_task"}]

--- a/modules/ecs_fargate_task/iam_ecs_execution.tf
+++ b/modules/ecs_fargate_task/iam_ecs_execution.tf
@@ -65,6 +65,10 @@ data "aws_iam_policy_document" "ecs_execution_container_policy" {
 }
 
 data "aws_iam_policy_document" "ecs_inject_container_secrets_policy" {
+  depends_on = [
+      aws_ssm_parameter.secure_param # otherwise doesn't get updated params until second apply
+  ]
+
   count = length(var.container_secrets) > 0 ? 1 : 0 # can only add this policy if there are ssm params 
   
   statement {

--- a/modules/ecs_fargate_task/ssm.tf
+++ b/modules/ecs_fargate_task/ssm.tf
@@ -20,8 +20,3 @@ resource "aws_ssm_parameter" "secure_param" {
     ignore_changes = [value]
   }
 }
-
-# create secrets map for ecs task definition
-locals {
-    container_ssm_map = zipmap(var.container_secrets, slice(aws_ssm_parameter.secure_param.*.arn, 0, length(var.container_secrets)))
-}


### PR DESCRIPTION
- Adds fargate service shared module 
- Updates documentation
- Moves fargate task container definition from template_file to inline. This is to resolve an issue where valueFrom not to be updated in task definition secrets on the first apply without a depends_on in the template_file (which caused terraform to read it weirdly and recreate the task definition every apply even if no changes). Because the template_file used a different provider, it was causing an issue with the order of execution that made the valueFrom not get updated in the definition though it was updated in the locals map. 

Both modules have been tested successfully with their respective example application.