### PR TITLE
tag ecs service and propagate tags to the tasks from the service

### DIFF
--- a/modules/ecs_fargate_service/ecs.tf
+++ b/modules/ecs_fargate_service/ecs.tf
@@ -62,6 +62,9 @@ resource "aws_ecs_service" "main" {
   task_definition = aws_ecs_task_definition.main.arn
   launch_type     = "FARGATE"
   desired_count   = var.task_count # number of instances to start with on new deployment 
+  
+  tags            = local.tags
+  propagate_tags  = "SERVICE"
 
   # container health and rolling deployments
   deployment_minimum_healthy_percent = var.ecs_deploy_min_healthy_perc

--- a/modules/ecs_fargate_service/variables.tf
+++ b/modules/ecs_fargate_service/variables.tf
@@ -2,6 +2,11 @@ variable "env" {}
 variable "task_name" {}
 variable "region" {}
 
+variable "tags" {
+    type = map(string)
+    default = {}
+}
+
 # Fargate Task
 variable "task_cpu" {
     type = number
@@ -67,11 +72,6 @@ variable "ecr_repository_arn" {}
 variable "ecr_image_tag" {
     type = string
     default = "latest"
-}
-
-variable "tags" {
-    type = map(string)
-    default = {}
 }
 
 # ALB


### PR DESCRIPTION
### purpose of change
tagging the service and tasks will be useful for cost analysis via tags, and will make it possible to search for the fargate services or tasks using aws's resource tagging API and resource type filters. 

### what changed
add tags to the ecs service and propagate tags to the tasks started by the service

### change tested
tested successfully with the example service