### PR TITLE
Add support for scheduled shutdown 

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Auto Scaling Inputs
 | memory_target | Target memory utilization. | No | number | 75 |
 | memory_scalein_cooldown | The minimum time (seconds) after a memory scalein before subsequent memory scalein events. e.g. reduce costs by allowing faster scale in  than the default AWS 300. | No | number | 180 |
 | memory_scaleout_cooldown | The minimum time (seconds) after a memory scaleout before subsequent memory scaleout events. Set at least as long as it takes for your memory load to normalize after scaling out so you don't overscale. | No | number | 180 | 
+| service_shutdown_schedules | Specifies times for stopping the service and restarting it again, e.g. saving costs by stopping the service in dev/test on nights and weekends. The shutdown/startup string values must be AWS Scheduling Expressions. | No | map(map(object({shutdown  = string, startup = string}))) | {} |
 
 Load Balancer Health Check Inputs:
 The load balancer sends periodic requests to the registered tasks to check their status. It will replace unhealthy tasks. 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Auto Scaling Inputs
 | memory_target | Target memory utilization. | No | number | 75 |
 | memory_scalein_cooldown | The minimum time (seconds) after a memory scalein before subsequent memory scalein events. e.g. reduce costs by allowing faster scale in  than the default AWS 300. | No | number | 180 |
 | memory_scaleout_cooldown | The minimum time (seconds) after a memory scaleout before subsequent memory scaleout events. Set at least as long as it takes for your memory load to normalize after scaling out so you don't overscale. | No | number | 180 | 
-| service_shutdown_schedules | Specifies times for stopping the service and restarting it again, e.g. saving costs by stopping the service in dev/test on nights and weekends. The shutdown/startup string values must be AWS Scheduling Expressions. | No | map(map(object({shutdown  = string, startup = string}))) | {} |
+| service_shutdown_schedules | Specifies times for stopping the service and restarting it again, e.g. to save costs by stopping dev/test on nights/weekends. The shutdown/startup string values must be AWS Scheduling Expressions and can be recurring crons or one-time events. Use short descriptive names as the keys for the startup/shutdown pairs. | No | map(map(object({shutdown  = string, startup = string}))) | {} |
 
 Load Balancer Health Check Inputs:
 The load balancer sends periodic requests to the registered tasks to check their status. It will replace unhealthy tasks. 

--- a/modules/ecs_fargate_service/app_schedule.tf
+++ b/modules/ecs_fargate_service/app_schedule.tf
@@ -1,0 +1,37 @@
+# specify the new capacity - specify minimum, maximum, or both
+# autoscaling will scale to the specified capacity at the scheduled time
+# Scheduled Action does not keep track of old values and return to them after the end time
+# so you must have a second action that returns it to the previous value at a certain time
+
+# shutdown schedule
+# if value for max is below the current capacity, autoscaling scales in to maxcapacity
+resource "aws_appautoscaling_scheduled_action" "shutdown" {
+  for_each = var.service_shutdown_schedules
+
+  name               = "${var.task_name}-shutdown-${each.key}-${var.env}"
+  service_namespace  = aws_appautoscaling_target.ecs_target.service_namespace
+  resource_id        = aws_appautoscaling_target.ecs_target.resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs_target.scalable_dimension
+  schedule           = each.value["shutdown"]
+  
+  scalable_target_action {
+    max_capacity = 0
+  }
+}
+
+# startup schedule
+# if value for min is above the current capacity, autoscaling scales out to min capacity
+resource "aws_appautoscaling_scheduled_action" "startup" {
+  for_each = var.service_shutdown_schedules
+
+  name               = "${var.task_name}-startup-${each.key}-${var.env}"
+  service_namespace  = aws_appautoscaling_target.ecs_target.service_namespace
+  resource_id        = aws_appautoscaling_target.ecs_target.resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs_target.scalable_dimension
+  schedule           = each.value["startup"]
+
+  scalable_target_action {
+    min_capacity = var.min_capacity # return to normal target tracking autoscaling rules. count will be raised to min and then target tracking will decide whether it needs further scaling out. 
+    max_capacity = var.max_capacity # re-raise max capacity or it won't let you set the min_capacity to above it   
+  }
+}

--- a/modules/ecs_fargate_service/variables.tf
+++ b/modules/ecs_fargate_service/variables.tf
@@ -144,10 +144,19 @@ variable "hc_grace_period" {
 
 # ECS Deploy
 variable "ecs_deploy_min_healthy_perc" {
- type = number
- default = 100
+    type = number
+    default = 100
 }
 variable "ecs_deploy_max_perc" {
- type = number
- default = 200
+    type = number
+    default = 200
+}
+
+# Application Scheduled Autoscaling
+variable "service_shutdown_schedules" {
+    type = map(object({
+        shutdown  = string
+        startup = string
+    }))
+    default = {}
 }


### PR DESCRIPTION
This adds support for stopping the service (and subsequently starting it again) on specified schedules by using App Autoscaling Scheduled Events to set the max capacity to 0 and then back to the original capacity. 

For now the scheduled actions only shut down and restart the service and you can't specify other scheduled capacity values for these (e.g. setting the capacity to 2 on a schedule instead of stopping it) because I want to encourage the practice of shutting down the lower environments when unused (and I think that's our most common use case, most others should probably use target tracking or step scaling anyways), but we can revisit it if that seems too prescriptive for the shared module. 

- tested successfully with the example Fargate service in the ADO sandbox
- documentation updated 



