### PR TITLE
Make the cloudwatch event optional 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Available inputs to pass into the modules:
 | subnet_ids | One or more subnets for the fargate ENI to attach to. | Yes | list(string) | Required parameters do not have a default. | 
 | assign_public_ip | Whether to assign a public IP address to the ENI | No | boolean | false |
 | cw_status | Whether to enable or disable the cloudwatch rule | Yes | boolean | Required parameters do not have a default. | 
-| cw_schedule | The cloudwatch schedule expression to use | Yes | string | Required parameters do not have a default. | 
+| cw_schedule | The cloudwatch schedule expression to use | No | string | null | 
 | container_env_variables | A list of environment variable maps for your container. Do not include secrets. | No | list(object({name  = string, value = string})) | [] |
 | container_secrets | A list of secrets to create in SSM and inject into the container at runtime. If updated, already running containers will not get new values/params. Names should match Jenkins credential IDs and will be available as env variables when the container runs. Do not use dashes/hyphens. | No | list(string) | [] |
 | container_port_mappings | The list of port mappings for the container | No | list(object({containerPort = number, hostPort = number, protocol = string})) | [] |

--- a/modules/ecs_fargate_task/cw_events.tf
+++ b/modules/ecs_fargate_task/cw_events.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_event_rule" "task_schedule" {
-    count = var.cw_schedule != null ? 0 : 1 # only create if a cloudwatch schedule is provided as an input
+    count = var.cw_schedule != null ? 1 : 0 # only create if a cloudwatch schedule is provided as an input
 
     name                = "${local.task_short_name}-${var.env}"
     schedule_expression = var.cw_schedule
@@ -8,7 +8,7 @@ resource "aws_cloudwatch_event_rule" "task_schedule" {
 }
 
 resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {
-    count = var.cw_schedule != null ? 0 : 1 # only create if a cloudwatch schedule is provided as an input
+    count = var.cw_schedule != null ? 1 : 0 # only create if a cloudwatch schedule is provided as an input
 
     arn       = aws_ecs_cluster.main.arn
     rule      = aws_cloudwatch_event_rule.task_schedule.name

--- a/modules/ecs_fargate_task/cw_events.tf
+++ b/modules/ecs_fargate_task/cw_events.tf
@@ -1,4 +1,6 @@
 resource "aws_cloudwatch_event_rule" "task_schedule" {
+    count = var.cw_schedule != null ? 0 : 1 # only create if a cloudwatch schedule is provided as an input
+
     name                = "${local.task_short_name}-${var.env}"
     schedule_expression = var.cw_schedule
     is_enabled          = var.cw_status
@@ -6,6 +8,8 @@ resource "aws_cloudwatch_event_rule" "task_schedule" {
 }
 
 resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {
+    count = var.cw_schedule != null ? 0 : 1 # only create if a cloudwatch schedule is provided as an input
+
     arn       = aws_ecs_cluster.main.arn
     rule      = aws_cloudwatch_event_rule.task_schedule.name
     role_arn  = aws_iam_role.cw_event_execution_role.arn

--- a/modules/ecs_fargate_task/cw_events.tf
+++ b/modules/ecs_fargate_task/cw_events.tf
@@ -11,8 +11,8 @@ resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {
     count = var.cw_schedule != null ? 1 : 0 # only create if a cloudwatch schedule is provided as an input
 
     arn       = aws_ecs_cluster.main.arn
-    rule      = aws_cloudwatch_event_rule.task_schedule.name
-    role_arn  = aws_iam_role.cw_event_execution_role.arn
+    rule      = aws_cloudwatch_event_rule.task_schedule[0].name
+    role_arn  = aws_iam_role.cw_event_execution_role[0].arn
 
     ecs_target {
         launch_type         = "FARGATE"

--- a/modules/ecs_fargate_task/iam_cw_events.tf
+++ b/modules/ecs_fargate_task/iam_cw_events.tf
@@ -1,5 +1,7 @@
 # for cloudwatch events to execute the ecs task
 data "aws_iam_policy_document" "cw_execution_assume_role_policy" {
+  count = var.cw_schedule != null ? 0 : 1 # only create if a cloudwatch schedule is provided as an input
+
   statement {
     actions = ["sts:AssumeRole"]
 
@@ -15,6 +17,8 @@ data "aws_iam_policy_document" "cw_execution_assume_role_policy" {
 # so event role doesn't have the permissions to run the latest task definition
 
 data "aws_iam_policy_document" "cw_role_policy" {
+  count = var.cw_schedule != null ? 0 : 1 # only create if a cloudwatch schedule is provided as an input
+
   depends_on = [aws_ecs_task_definition.main]
 
   statement {
@@ -56,6 +60,8 @@ data "aws_iam_policy_document" "cw_role_policy" {
 }
 
 resource "aws_iam_role" "cw_event_execution_role" {
+  count = var.cw_schedule != null ? 0 : 1 # only create if a cloudwatch schedule is provided as an input
+
   name                  = "${local.task_short_name}-cw-event-role-${var.env}"
   assume_role_policy    = data.aws_iam_policy_document.cw_execution_assume_role_policy.json
   description           = "CW Execution Role for ${local.task_short_name} ECS"
@@ -63,6 +69,8 @@ resource "aws_iam_role" "cw_event_execution_role" {
 }
 
 resource "aws_iam_role_policy" "cw_role_policy" {
+  count = var.cw_schedule != null ? 0 : 1 # only create if a cloudwatch schedule is provided as an input
+
   name   = "${local.task_short_name}-cw-event-role-policy-${var.env}"
   role   = aws_iam_role.cw_event_execution_role.id
   policy = data.aws_iam_policy_document.cw_role_policy.json

--- a/modules/ecs_fargate_task/iam_cw_events.tf
+++ b/modules/ecs_fargate_task/iam_cw_events.tf
@@ -63,7 +63,7 @@ resource "aws_iam_role" "cw_event_execution_role" {
   count = var.cw_schedule != null ? 1 : 0 # only create if a cloudwatch schedule is provided as an input
 
   name                  = "${local.task_short_name}-cw-event-role-${var.env}"
-  assume_role_policy    = data.aws_iam_policy_document.cw_execution_assume_role_policy.json
+  assume_role_policy    = data.aws_iam_policy_document.cw_execution_assume_role_policy[0].json
   description           = "CW Execution Role for ${local.task_short_name} ECS"
   tags                  = local.tags
 }
@@ -72,6 +72,6 @@ resource "aws_iam_role_policy" "cw_role_policy" {
   count = var.cw_schedule != null ? 1 : 0 # only create if a cloudwatch schedule is provided as an input
 
   name   = "${local.task_short_name}-cw-event-role-policy-${var.env}"
-  role   = aws_iam_role.cw_event_execution_role.id
-  policy = data.aws_iam_policy_document.cw_role_policy.json
+  role   = aws_iam_role.cw_event_execution_role[0].id
+  policy = data.aws_iam_policy_document.cw_role_policy[0].json
 }

--- a/modules/ecs_fargate_task/iam_cw_events.tf
+++ b/modules/ecs_fargate_task/iam_cw_events.tf
@@ -1,6 +1,6 @@
 # for cloudwatch events to execute the ecs task
 data "aws_iam_policy_document" "cw_execution_assume_role_policy" {
-  count = var.cw_schedule != null ? 0 : 1 # only create if a cloudwatch schedule is provided as an input
+  count = var.cw_schedule != null ? 1 : 0 # only create if a cloudwatch schedule is provided as an input
 
   statement {
     actions = ["sts:AssumeRole"]
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "cw_execution_assume_role_policy" {
 # so event role doesn't have the permissions to run the latest task definition
 
 data "aws_iam_policy_document" "cw_role_policy" {
-  count = var.cw_schedule != null ? 0 : 1 # only create if a cloudwatch schedule is provided as an input
+  count = var.cw_schedule != null ? 1 : 0 # only create if a cloudwatch schedule is provided as an input
 
   depends_on = [aws_ecs_task_definition.main]
 
@@ -60,7 +60,7 @@ data "aws_iam_policy_document" "cw_role_policy" {
 }
 
 resource "aws_iam_role" "cw_event_execution_role" {
-  count = var.cw_schedule != null ? 0 : 1 # only create if a cloudwatch schedule is provided as an input
+  count = var.cw_schedule != null ? 1 : 0 # only create if a cloudwatch schedule is provided as an input
 
   name                  = "${local.task_short_name}-cw-event-role-${var.env}"
   assume_role_policy    = data.aws_iam_policy_document.cw_execution_assume_role_policy.json
@@ -69,7 +69,7 @@ resource "aws_iam_role" "cw_event_execution_role" {
 }
 
 resource "aws_iam_role_policy" "cw_role_policy" {
-  count = var.cw_schedule != null ? 0 : 1 # only create if a cloudwatch schedule is provided as an input
+  count = var.cw_schedule != null ? 1 : 0 # only create if a cloudwatch schedule is provided as an input
 
   name   = "${local.task_short_name}-cw-event-role-policy-${var.env}"
   role   = aws_iam_role.cw_event_execution_role.id

--- a/modules/ecs_fargate_task/outputs.tf
+++ b/modules/ecs_fargate_task/outputs.tf
@@ -27,7 +27,7 @@ output "cw_log_stream_prefix" {
 }
 
 output "parameters" {
-    value = zipmap(join(var.container_secrets, var.secrets_suffix), slice(aws_ssm_parameter.secure_param.*.name, 0, length(var.container_secrets)))
+    value = zipmap(formatlist("%s${var.secrets_suffix}", var.container_secrets), slice(aws_ssm_parameter.secure_param.*.name, 0, length(var.container_secrets)))
 }
 
 output "kms_arn" {

--- a/modules/ecs_fargate_task/outputs.tf
+++ b/modules/ecs_fargate_task/outputs.tf
@@ -27,7 +27,7 @@ output "cw_log_stream_prefix" {
 }
 
 output "parameters" {
-    value = zipmap(var.container_secrets, slice(aws_ssm_parameter.secure_param.*.name, 0, length(var.container_secrets)))
+    value = zipmap(join(var.container_secrets, var.secrets_suffix), slice(aws_ssm_parameter.secure_param.*.name, 0, length(var.container_secrets)))
 }
 
 output "kms_arn" {

--- a/modules/ecs_fargate_task/variables.tf
+++ b/modules/ecs_fargate_task/variables.tf
@@ -58,9 +58,11 @@ variable "aws_security_group" {
 
 # CW Rules
 variable "cw_status" {
-    type = bool
+    type = bool # I think people could still set this as false if they don't want to use cw 
 }
-variable "cw_schedule" {}
+variable "cw_schedule" {
+    default = null # optional - mark as unset if none provided 
+}
 
 # ECR
 variable "ecr_repository_url"{}

--- a/modules/ecs_fargate_task/variables.tf
+++ b/modules/ecs_fargate_task/variables.tf
@@ -34,6 +34,9 @@ variable "container_secrets" {
     type = list(string)
     default = []
 }
+variable "secrets_suffix" {
+    default = "" # optional - mark as unset if none provided 
+}
 variable "container_port_mappings" {
     type = list(object({
         containerPort = number


### PR DESCRIPTION
Make the cloudwatch event optional. The use case for adding this was so the fargate task can be used within a step function where the cloudwatch event invokes the step function which invokes the fargate task, rather than a cloudwatch event invoking the fargate task directly. 

tested during development of the Alumni ETLS 